### PR TITLE
ci: Do not package action when running integration tests on release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npm run package
+      - name: Package action for integration tests
+        if: ${{ github.ref != 'refs/heads/release' }}
+        run: npm run package
       - id: default
         uses: ./
       - name: Test actor is greeted by default


### PR DESCRIPTION
An integration test of the release needs to test that the `dist` included works as it is distributed -- it should not touch the package before testing.