### PR TITLE
ci: Remove secrets branch configuration

### DIFF
--- a/.github/workflows/sync-release-branch.yml
+++ b/.github/workflows/sync-release-branch.yml
@@ -6,8 +6,8 @@ on:
       - "main"
 
 env:
-  source: ${{ secrets.BRANCHES_SOURCE || 'main' }}
-  release: ${{ secrets.BRANCHES_RELEASE || 'release' }}
+  source: "origin/main"
+  release: "release"
 
 jobs:
   update-branch:
@@ -20,4 +20,4 @@ jobs:
           ssh-key: "${{ secrets.COMMIT_KEY }}"
       - uses: pr-mpt/actions-merge-branch@v1
         with:
-          from: "origin/${{ env.source }}"
+          from: "${{ env.source }}"


### PR DESCRIPTION
The secrets for `source` and `release` weren't used.