### PR TITLE
ci: Package action for all integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: npm install
       - name: Package action for integration tests
-        if: "!startsWith(github.ref, 'refs/heads/release')"
         run: npm run package
       - id: default
         uses: ./


### PR DESCRIPTION
The exclusion of packaging of the action on the `release` branch was intended to verify that the repository contains the packaged action -- but that check should be an explicit test.

Closes #8 