### PR TITLE
fix: Merge and package in single Job

### DIFF
--- a/.github/workflows/package-action.yml
+++ b/.github/workflows/package-action.yml
@@ -3,16 +3,25 @@ name: "Package Action"
 on:
   push:
     branches:
-      - "release"
-      - "release/**"
+      - "main"
+
+env:
+  source: "origin/main"
+  release: "release"
 
 jobs:
-  push-changes:
+  package-changes:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: "${{ env.release }}"
+          fetch-depth: 0
           ssh-key: "${{ secrets.COMMIT_KEY }}"
+      - uses: pr-mpt/actions-merge-branch@v2
+        with:
+          from: "${{ env.source }}"
+          commit: false
       - name: Install Javascript dependencies with npm
         run: npm install
       - name: Package action for distribution


### PR DESCRIPTION
The new changes from the `source` branch are merged into the current working copy of the Action, then it is packaged and the changes -- `source` and `dist` -- are pushed to the `release` branch.

Fixes #8
Closes #11